### PR TITLE
feat(commit-generator): add difference output to commit prompt

### DIFF
--- a/gitagent/agent_features/commit_generator.py
+++ b/gitagent/agent_features/commit_generator.py
@@ -39,6 +39,7 @@ class CommitGenerator():
         console.print(Panel("[gray]Agent is thinking...[/gray]"))
         
         diff = self.get_difference()
+        print(f"difference: {diff}")
         prompt = PROMPT_COMMIT.format(diff=diff)
 
         try:


### PR DESCRIPTION
This change adds a print statement to display the difference in the commit prompt. This will help users understand the changes they are committing.

* Added print statement to display difference